### PR TITLE
Add examples to show association of const/var

### DIFF
--- a/sub/somefile.go
+++ b/sub/somefile.go
@@ -50,11 +50,11 @@ var (
 	Pear = NewFood(PearName)
 )
 
-// Favourite is a global variable in the package.
+// Favorite is a global variable in the package.
 //
 // Because it is declared with a type defined within the package, it is
 // sorted with the type definition in the documentation.
-var Favourite Food = Pear
+var Favorite Food = Pear
 
 // Food is a type to show how type documentation works.
 //


### PR DESCRIPTION
I've tried to keep this in the tone of the rest of the document. There is some redundancy (Food and Weight are both used to demonstrate var association), but I think the the two different ways of declaring your package-level Food vars helps clarify the difference between `var V T = Exp` and `var V = T(Exp)` in godoc's view.

I was considering writing 'Because Favourite is declared ...' at L#53, but the double capitalisation looked ugly (and you have not done this except for Applename) so I skirted the issue by using 'it'

Also. You may want to check for spelling as American in case I forgot any words.
