### PR TITLE
Simplify package description.

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -1,7 +1,7 @@
 // Note that you must leave a blank line between the copyright header and your
 // actual doc string, to avoid having this documentation shown in godoc.
 
-// Command godocgo is a repo demonstrating effective Go documentation.
+// godocgo is a repo demonstrating effective Go documentation.
 //
 // Introduction
 //


### PR DESCRIPTION
This PR is a style improvement suggestion for your consideration.

Go style suggests, as verified by `golint`, that Go packages that are libraries (i.e., package name is not "main") package description begin with "Package {{.Name}} ...". I used to think this applied to commands as well, but I've learned that's not the case. There's no explicit requirement to start package descriptions for commands (i.e., Go package with name "main") with "Command {{.Name}} ...".

That allows to simplify the package description by omitting that word.
